### PR TITLE
Fix buffer overflow in M_LoadDefaults

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -981,7 +981,7 @@ void M_LoadDefaults (void)
     while (!feof(f))
       {
       isstring = false;
-      if (fscanf (f, "%79s %[^\n]\n", def, strparm) == 2)
+      if (fscanf (f, "%79s %99[^\n]\n", def, strparm) == 2)
         {
 
         //jff 3/3/98 skip lines not starting with an alphanum


### PR DESCRIPTION
If `fscanf` doesn't limit the number of characters to be read, it can lead to a buffer overflow which allows for arbitrary code execution. 

CVE-2020-15007: https://nvd.nist.gov/vuln/detail/CVE-2020-15007